### PR TITLE
fix: AI解析結果がレポートに正しく反映されるよう修正

### DIFF
--- a/client/src/hooks/use-weekly-report-form.ts
+++ b/client/src/hooks/use-weekly-report-form.ts
@@ -399,6 +399,8 @@ export function useWeeklyReportForm({ id, latestVersionFromAutoSave }: UseWeekly
         });
         // 管理者編集完了時は result.report.id を使用
         setLocation(`/reports/${result.report?.id || id}`);
+        // AI分析結果が更新されるため、レポート詳細クエリを無効化して再フェッチをトリガー
+        queryClient.invalidateQueries({ queryKey: [`/api/weekly-reports/${id}`] });
       } else {
         toast({
           title: isEditMode ? "報告が更新されました" : "報告が送信されました",
@@ -409,6 +411,8 @@ export function useWeeklyReportForm({ id, latestVersionFromAutoSave }: UseWeekly
         });
         // 通常の編集・作成時は result.id を使用
         setLocation(`/reports/${result.id}`);
+        // AI分析結果が更新される可能性があるため、レポート詳細クエリを無効化して再フェッチをトリガー
+        queryClient.invalidateQueries({ queryKey: [`/api/weekly-reports/${id}`] });
       }
     },
     onError: async (error: any) => {

--- a/client/src/pages/weekly-report.tsx
+++ b/client/src/pages/weekly-report.tsx
@@ -79,6 +79,19 @@ export default function WeeklyReport() {
     isInitializing,
   } = formHook;
 
+  // デバッグログの追加
+  useEffect(() => {
+    if (existingReport) {
+      console.log('[DEBUG] WeeklyReport Component - existingReport loaded:', {
+        reportId: existingReport.id,
+        aiAnalysisLength: existingReport.aiAnalysis?.length,
+        aiAnalysisPreview: existingReport.aiAnalysis ? existingReport.aiAnalysis.substring(0, 200) : 'N/A',
+        isEditMode,
+        isAdminEditMode,
+      });
+    }
+  }, [existingReport, isEditMode, isAdminEditMode]);
+
   // 簡素化：版数コンフリクト状態の監視を削除
 
   const autoSaveHook = useReportAutoSave({ 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1764,10 +1764,12 @@ Markdown形式で作成し、適切な見出しを使って整理してくださ
           // 修正会議議事録を保存
           storage.upsertWeeklyReportMeeting(meetingData),
           // 管理者確認メール文章を保存（生成に成功した場合のみ）
-          adminConfirmationEmail 
+          adminConfirmationEmail
             ? (() => {
-                const currentData = { ...updatedReport, adminConfirmationEmail };
-                const { id: reportId, createdAt, ...updateData } = currentData;
+                // updatedReport には aiAnalysis が含まれていないため、
+                // analysis (エグゼクティブサマリ) を明示的に含める
+                const reportToUpdate = { ...updatedReport, aiAnalysis: analysis, adminConfirmationEmail };
+                const { id: reportId, createdAt, ...updateData } = reportToUpdate;
                 return storage.updateWeeklyReport(id, updateData);
               })()
             : Promise.resolve(),
@@ -2136,8 +2138,11 @@ Markdown形式で作成し、適切な見出しを使って整理してくださ
       const stage2Duration = Date.now() - stage2StartTime;
       const totalDuration = Date.now() - startTime;
       console.log(`✅ 第2段階完了 (${stage2Duration}ms) - サマリ長: ${executiveSummary.length}`);
+      console.log(`[DEBUG] analyzeWeeklyReport - executiveSummary content preview: ${executiveSummary.substring(0, 200)}...`);
       console.log(`🎉 2段階AI分析完了 (総時間: ${totalDuration}ms)`);
 
+      console.log(`[DEBUG] analyzeWeeklyReport - Final executiveSummary length: ${executiveSummary.length}`);
+      console.log(`[DEBUG] analyzeWeeklyReport - Final executiveSummary preview: ${executiveSummary.substring(0, 200)}...`);
       return executiveSummary;
 
     } catch (error) {
@@ -2363,6 +2368,8 @@ A5: [分析結果に基づく回答]`
       },
     );
 
+    console.log(`[DEBUG] generateWeeklyReportExecutiveSummary - AI response content length: ${response.content.length}`);
+    console.log(`[DEBUG] generateWeeklyReportExecutiveSummary - AI response content preview: ${response.content.substring(0, 200)}...`);
     return response.content;
   }
 


### PR DESCRIPTION
- クライアント側 週次レポート詳細のクエリ（/api/weekly-reports/:id）を、レポートの送信または更新後に無効化。これにより、AI解析結果を含む最新のレポートデータが再取得されるように。
- サーバー側 管理者確認メールの生成後、週次レポートを更新する際に aiAnalysis の内容を明示的に渡すことで、処理中に生成されたAI解析結果が確実にデータベースへ保存されるよう保証。
- デバッグ AI解析結果の生成時およびクライアント側での読み込み時に、内容と文字数を確認するためのコンソールログを追加。