### PR TITLE
アプリケーションのタイムアウトを30分に標準化

### DIFF
--- a/client/src/hooks/use-report-auto-save.ts
+++ b/client/src/hooks/use-report-auto-save.ts
@@ -201,14 +201,14 @@ export function useReportAutoSave({ form, isEditMode, id, currentVersion, onVers
     };
   }, [formChanged, autoSave, isEditMode, isSubmitting, isInitializing]);
 
-  // 5分間隔のバックアップ保存（変更がある場合のみ）
+  // 3分間隔のバックアップ保存（変更がある場合のみ、セッション30分に対して適切な頻度）
   useEffect(() => {
     autoSaveTimerRef.current = setInterval(() => {
       if (formChanged && !isSubmitting) {
         devLog("⏰ Periodic auto-save triggered");
         autoSave();
       }
-    }, 5 * 60 * 1000);
+    }, 3 * 60 * 1000);
 
     return () => {
       if (autoSaveTimerRef.current) {

--- a/server/db.ts
+++ b/server/db.ts
@@ -27,14 +27,14 @@ if (isLocal) {
   console.log('リモートPostgreSQL環境に接続します');
 }
 
-// Neonの場合は接続プールの設定を調整（離席後のエラー対策を強化）
+// Neonの場合は接続プールの設定を調整（30分統一タイムアウト対応）
 const poolConfig = isNeon ? {
   connectionString: databaseUrl,
-  connectionTimeoutMillis: 120000,  // 2分に延長（離席後の再接続時間を考慮）
-  idleTimeoutMillis: 900000,       // 15分に延長（Neonのアイドルタイムアウトに合わせる）
-  max: 3,                          // 接続数をさらに削減してリソース効率化
+  connectionTimeoutMillis: 120000,  // 2分
+  idleTimeoutMillis: 1800000,      // 30分（セッション管理と統一）
+  max: 3,                          // 接続数を適度に設定
   min: 1,                          // 最低1つの接続を維持
-  acquireTimeoutMillis: 120000,    // 取得タイムアウトも2分に延長
+  acquireTimeoutMillis: 60000,     // 取得タイムアウト1分
   keepAlive: true,                 // TCP Keep-Aliveを有効化
   keepAliveInitialDelayMillis: 0,  // Keep-Alive開始遅延なし
   ssl: { rejectUnauthorized: false }
@@ -67,13 +67,13 @@ pool.on('error', (err) => {
       console.warn('PostgreSQL Pool Error:', err.message);
       console.info('🔄 データベース接続が切断されました。次回のクエリ時に自動再接続されます。');
       if (isNeon) {
-        console.info('💡 Neon環境: アイドルタイムアウト後の自動再接続です');
+        console.info('💡 Neon環境: 30分アイドルタイムアウト後の自動再接続です');
       }
     } else {
       console.error('PostgreSQL Pool Error:', err.message);
       console.log('🔄 データベース接続が切断されました。次回のクエリ時に自動再接続されます。');
       if (isNeon) {
-        console.log('💡 Neon環境: 15分のアイドルタイムアウト後の再接続です');
+        console.log('💡 Neon環境: 30分アイドルタイムアウト後の再接続です');
       }
     }
   } else {

--- a/server/index.ts
+++ b/server/index.ts
@@ -70,7 +70,7 @@ app.use(
     cookie: {
       secure: false, // 開発環境では常にfalse（HTTPSでなくても動作）
       sameSite: 'lax', // 開発環境用に緩和（strictから変更）
-      maxAge: 4 * 60 * 60 * 1000, // 4時間（MemoryStore TTLと統一）
+      maxAge: 30 * 60 * 1000, // 30分（DB接続プールと統一）
       httpOnly: true, // XSS対策は維持
       domain: undefined // 開発環境ではdomainを指定しない
     },


### PR DESCRIPTION
さまざまなアプリケーションのタイムアウトを統一し、ユーザー体験の向上を図ります。
- クライアント側の自動保存間隔を5分から3分に短縮し、30分のセッション内でより頻繁にバックアップを実施
- Neon PostgreSQL の接続プールのアイドルタイムアウトを15分から30分に延長し、新しいセッション時間と一致させる
- データベース接続の取得タイムアウトを1分に調整
- セッションクッキーの maxAge を4時間から30分に変更し、DB接続プールおよびセッション管理全体と同期